### PR TITLE
Add backend env example and document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,19 @@ npm install
 npm start
 ```
 
+### 🔐 Environment Variables
+
+GrindMap uses environment variables for backend configuration.
+
+#### Backend Setup
+
+Create a `.env` file inside the `backend` directory using the provided `.env.example` as reference.
+
+```bash
+cd backend
+cp .env.example .env
+
+
 ### Alternative: Docker Setup 🐳
 
 For a containerized setup with consistent environments across machines:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+# Server
+PORT=5000
+
+# Authentication
+JWT_SECRET=your_jwt_secret_here
+
+# Database
+MONGO_URI=mongodb://127.0.0.1:27017/grindmap


### PR DESCRIPTION
I have added a .env.example file inside the backend directory to list all required environment variables with example values.

I have also updated the root README.md to document these variables and explain how to set up the backend environment for local development.

Environment variables are currently used only in the backend, so the .env.example file has been added under the backend directory instead of the repository root.

This improves onboarding and removes guesswork for new contributors.