### PR TITLE
Add API base URL env var and refactor fetch URLs

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# The base URL for the backend API
+VITE_API_URL=http://localhost:5000

--- a/frontend/src/hooks/useGrindMapData.js
+++ b/frontend/src/hooks/useGrindMapData.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { PLATFORMS } from "../utils/platforms";
 
+const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
 export const useGrindMapData = () => {
   const [usernames, setUsernames] = useState({
     leetcode: "",
@@ -30,7 +31,7 @@ export const useGrindMapData = () => {
       let data = null;
       if (plat.key === "leetcode") {
         const res = await fetch(
-          `http://localhost:5000/api/leetcode/${username}`,
+          `${API_BASE_URL}/api/leetcode/${username}`,
         );
         const result = await res.json();
         if (result.data) {
@@ -40,7 +41,7 @@ export const useGrindMapData = () => {
         }
       } else if (plat.key === "codeforces") {
         const res = await fetch(
-          `http://localhost:5000/api/codeforces/${username}`,
+          `${API_BASE_URL}/api/codeforces/${username}`,
         );
         const result = await res.json();
         if (result.success && result.data) {
@@ -56,7 +57,7 @@ export const useGrindMapData = () => {
         }
       } else if (plat.key === "codechef") {
         const res = await fetch(
-          `http://localhost:5000/api/codechef/${username}`,
+          `${API_BASE_URL}/api/codechef/${username}`,
         );
         const result = await res.json();
         if (result.success && result.data) {


### PR DESCRIPTION
Introduced a .env.example file with VITE_API_URL for backend API configuration. Updated useGrindMapData hook to use the environment variable for API requests instead of hardcoded URLs, improving flexibility and environment management.

📌 Description
This PR addresses the issue of hardcoded backend API URLs by implementing an environment-based configuration. By utilizing Vite's environment variable system, the frontend can now dynamically point to different backend instances (local, staging, or production) without manual code changes.

Key Features:

Decoupled API Logic: Moved hardcoded http://localhost:5000 strings into a central constant powered by environment variables.

Environment Template: Added .env.example to provide a clear blueprint for other contributors.

Vite Integration: Used import.meta.env to comply with the project's build tool requirements.
Fixes: #49

🔧 Type of Change
Please mark the relevant option(s):

☐ 🐛 Bug fix
☐✨ New feature
☐📝 Documentation update
☑ ♻️ Refactor / Code cleanup
☐ 🎨 UI / Styling change
☐ 🚀 Other (please describe):

🧪 How Has This Been Tested?
Describe the tests you ran to verify your changes.

☑ Manual testing
☐ Automated tests
☐ Not tested (please explain why)


✅ Checklist
Please confirm the following:

☑ My code follows the project's coding style
☑ I have tested my changes
☑ I have updated documentation where necessary
☑ This PR does not introduce breaking changes

📝 Additional Notes

Files Modified/Created:

frontend/.env.example: New template file.

frontend/src/hooks/useGrindMapData.js: Updated fetch logic to use VITE_API_URL.