### PR TITLE
[UI/UX] Add descriptive hover tooltips to platform progress rings

### DIFF
--- a/frontend/src/components/CircularProgress.jsx
+++ b/frontend/src/components/CircularProgress.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 
-const CircularProgress = ({ percentage, solved, goal, color, size = 'medium' }) => {
+const CircularProgress = ({ percentage, solved, goal, color, size = 'medium', tooltip }) => {
   const sizes = {
     small: 100,
     medium: 150,
@@ -19,7 +19,7 @@ const CircularProgress = ({ percentage, solved, goal, color, size = 'medium' }) 
   const progressColor = color || 'var(--theme-progress)';
 
   return (
-    <div style={{ width: `${width}px`, height: `${width}px`, margin: '20px auto' }}>
+    <div style={{ width: `${width}px`, height: `${width}px`, margin: '20px auto' }} title={tooltip}>
       <CircularProgressbar
         value={calculatedPercentage}
         text={`${calculatedPercentage}%`}

--- a/frontend/src/components/PlatformCard.jsx
+++ b/frontend/src/components/PlatformCard.jsx
@@ -36,6 +36,7 @@ const PlatformCard = ({
               percentage={percentage}
               color={platform.color}
               size={isExpanded ? "large" : "medium"}
+              tooltip="No data"
             />
           </div>
         </div>
@@ -60,6 +61,7 @@ const PlatformCard = ({
               percentage={0}
               color={platform.color}
               size={isExpanded ? "large" : "medium"}
+              tooltip={data.error || "Error"}
             />
           </div>
         </div>
@@ -74,6 +76,12 @@ const PlatformCard = ({
       onToggle(platform.key);
     }
   };
+
+  const tooltipText = data.totalSolved !== undefined
+    ? `Solved: ${data.totalSolved} / ${data.totalQuestions || "Unknown"}`
+    : data.solved !== undefined
+      ? `Solved: ${data.solved}`
+      : `Percentage: ${percentage}%`;
 
   return (
     <div
@@ -94,6 +102,7 @@ const PlatformCard = ({
             percentage={percentage}
             color={platform.color}
             size={isExpanded ? "large" : "medium"}
+            tooltip={tooltipText}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR adds tooltips to the `CircularProgress` component to display raw data (e.g., "Solved: 487/600") when hovering over the progress rings. This provides users with more detailed information directly on the dashboard without needing to expand the cards.

## Changes Made

### 1. CircularProgress Component
- Added a `tooltip` prop to the `CircularProgress` component.
- Applied the `tooltip` as a `title` attribute to the component's container `div`, enabling native browser tooltips on hover.

### 2. PlatformCard Component
- Updated the usage of `CircularProgress` to calculate and pass the tooltip string.
- Implemented logic to handle different data states:
    - **With Total**: Displays "Solved: X / Y" (e.g., LeetCode where total is known).
    - **Without Total**: Displays "Solved: X" (e.g., CodeForces where total might be dynamic).
    - **Fallback**: Displays "Percentage: X%" if solved counts are missing.
    - **Error/Loading**: Displays appropriate status messages.

## Features

- **Instant Data Visibility**: Hover over any progress ring to see precise solved counts.
- **Context-Aware Tooltips**: Shows "Solved: X/Y" when the goal is known, or just "Solved: X" otherwise.
- **Error Handling**: Displays "No data" or specific error messages in the tooltip when data is unavailable.

## Testing

- [x] Verified tooltips appear correctly on all platform cards.
- [x] Verified correct format "Solved: X / Y" for platforms with total counts.
- [x] Verified correct format "Solved: X" for platforms without total counts.
- [x] Verified error state tooltips.
- [x] confirmed no regression in existing UI layout.

## Files Changed

- `frontend/src/components/CircularProgress.jsx`
- `frontend/src/components/PlatformCard.jsx`


### Related Issues : #322 

Label: ECWoC26
